### PR TITLE
add menu option for number of decimal digits in speedometer

### DIFF
--- a/ronin/resource/ui/menus/srm_speedometer_settings.menu
+++ b/ronin/resource/ui/menus/srm_speedometer_settings.menu
@@ -113,12 +113,29 @@ resource/ui/menus/srm_speedometer_settings.menu
 			pin_to_sibling_corner	BOTTOM_LEFT
 		}
 
+        SwchSpeedometerDecimals
+		{
+			ControlName				RuiButton
+			InheritProperties		SwitchButton
+			style					DialogListButton
+			ConVar					"srm_speedometer_decimals"
+			list
+			{
+				"0"				    0
+				"1"				    1
+				"2"				    2
+			}
+			pin_to_sibling			SwchSpeedometerAxisMode
+			pin_corner_to_sibling	TOP_LEFT
+			pin_to_sibling_corner	BOTTOM_LEFT
+		}
+
 		CustomizationSubheaderBackground
 		{
 			ControlName				ImagePanel
 			InheritProperties		SubheaderBackground
 			xpos					96
-			ypos					300
+			ypos					365
 		}
 		CustomizationSubheaderText
 		{

--- a/ronin/scripts/vscripts/client/srm_speedometer.nut
+++ b/ronin/scripts/vscripts/client/srm_speedometer.nut
@@ -102,13 +102,8 @@ void function SRM_SpeedometerUpdate()
 		RuiSetFloat3( file.speedometer, "msgColor", SRM_SpeedometerColorLerp( speed ) )
 		RuiSetFloat3( file.speedometerUnit, "msgColor", SRM_SpeedometerColorLerp( speed ) )
 		speed *= unitConversionModifier
-
-		// ugly way to do pow(10, digits)
-		int pivot = [1, 10, 100][GetConVarInt("srm_speedometer_decimals")]
-
-		//round to the correct number of digits and convert to string
-		speed = (((speed * pivot).tointeger().tofloat())/pivot )
-		RuiSetString( file.speedometer, "msgText", speed.tostring() )
+		// convert to string then round to the correct number of digits
+		RuiSetString( file.speedometer, "msgText", format("%." + GetConVarInt("srm_speedometer_decimals") + "f", speed) )
 	}
 }
 

--- a/ronin/scripts/vscripts/client/srm_speedometer.nut
+++ b/ronin/scripts/vscripts/client/srm_speedometer.nut
@@ -102,8 +102,13 @@ void function SRM_SpeedometerUpdate()
 		RuiSetFloat3( file.speedometer, "msgColor", SRM_SpeedometerColorLerp( speed ) )
 		RuiSetFloat3( file.speedometerUnit, "msgColor", SRM_SpeedometerColorLerp( speed ) )
 		speed *= unitConversionModifier
-		// cut off decimals and then convert to string
-		RuiSetString( file.speedometer, "msgText", speed.tointeger().tostring() )
+
+		// ugly way to do pow(10, digits)
+		int pivot = [1, 10, 100][GetConVarInt("srm_speedometer_decimals")]
+
+		//round to the correct number of digits and convert to string
+		speed = (((speed * pivot).tointeger().tofloat())/pivot )
+		RuiSetString( file.speedometer, "msgText", speed.tostring() )
 	}
 }
 

--- a/ronin/scripts/vscripts/ui/srm_menu_speedometer_settings.nut
+++ b/ronin/scripts/vscripts/ui/srm_menu_speedometer_settings.nut
@@ -9,6 +9,7 @@ void function SRM_InitSpeedometerSettingsMenu()
 	// functional settings
 	SRM_SetupNormalButton( "SwchSpeedometerUnit", "Unit", "Determines the measuring unit used for displaying the speed (kph/mph/u)\n\n`2Requires a reload for changes to take effect" )
 	SRM_SetupNormalButton( "SwchSpeedometerAxisMode", "Axis Mode", "Determine which axes the speedometer should measure" )
+	SRM_SetupNormalButton( "SwchSpeedometerDecimals", "Decimal Digits", "Determines how many decimal digits to show" )
 
 	// position
 	SRM_SetupSlider( "SldSpeedometerPositionX", "Position X", "Horizontal position of the Speedometer.\n`10.0`0 = Left\n`11.0`0 = Right"+mustReloadNote )


### PR DESCRIPTION
Adds a menu option in the speedometer menu for how many decimal digits to display. I know that dyed mentioned that they don't like the spacing when using decimals and so this PR is mostly for my some peace of mind of having put this out into the world. 

Because of the previously mentioned spacing, I haven't touched the option of km/h * 10 since some people most likely are going to prefer that. 

I also have no idea why anyone would like 2 decimals but it felt weird to make it just a toggle. 

Lastly, I couldn't find any good way of doing powers in squirrel and making a function for it felt clumsy. The result is a bit ugly but works at least. 

This PR would also have to go in hand with the addition of the convar to the SDK: https://github.com/TF2SR/RoninSDK/pull/19
