### PR TITLE
Version display + other fixes

### DIFF
--- a/ronin/scripts/vscripts/sp/srm_savestates.nut
+++ b/ronin/scripts/vscripts/sp/srm_savestates.nut
@@ -25,6 +25,7 @@ thread void function() : ()
         player.SetOrigin(file.position)
         player.SetAngles(file.angles)
         player.SetVelocity(file.velocity)
+        player.TouchGround()
         return true
     }
 

--- a/ronin/scripts/vscripts/timer/cl_timer_overlay.nut
+++ b/ronin/scripts/vscripts/timer/cl_timer_overlay.nut
@@ -164,7 +164,7 @@ void function UpdateTimerHUD()
         if (BT7274_ActivateNCS() && !isNCSActivated)
         {
             isNCSActivated = true
-            if (GetRunCategory() == "ANY%")
+            //if (GetRunCategory() == "ANY%")
                 RunUIScript("AddTime", 207210000) // 3:22.21
             // balls.
             GetLocalClientPlayer().ClientCommand("load fastany1")

--- a/ronin/scripts/vscripts/timer/cl_timer_overlay.nut
+++ b/ronin/scripts/vscripts/timer/cl_timer_overlay.nut
@@ -164,7 +164,7 @@ void function UpdateTimerHUD()
         if (BT7274_ActivateNCS() && !isNCSActivated)
         {
             isNCSActivated = true
-            if (GetRunCategory() == "ANY%")
+            //if (GetRunCategory() == "ANY%")
                 RunUIScript("AddTime", 202210000) // 3:22.21
             // balls.
             GetLocalClientPlayer().ClientCommand("load fastany1")

--- a/ronin/scripts/vscripts/ui/loading_screen.nut
+++ b/ronin/scripts/vscripts/ui/loading_screen.nut
@@ -28,7 +28,7 @@ void function LoadingScreen()
         }
         UpdateTimerHUD(timer)
 
-        Hud_SetText(timeLabel, GetUnixTimestamp().tostring())
+        Hud_SetText(timeLabel, GetUnixTimestamp().tostring() + "\n" + GetSdkVersion())
         //print(Hud_GetUTF8Text(modeLabel) + "HELO")
 
         //Hud_SetVisible(Hud_GetChild(loadingMenu, "LoadingTip"), true)

--- a/ronin/scripts/vscripts/ui/srm_subtitles.nut
+++ b/ronin/scripts/vscripts/ui/srm_subtitles.nut
@@ -11,6 +11,10 @@ void function SRM_UIInit() {
     ClientCommand("alias \"fgr\" \"sp_startpoint 0;map sp_training;sp_difficulty 0;sv_cheats 0;\"")
     ClientCommand("alias \"sr_reset_anypercent\" \"script_ui ResetAnyPercent()\"")
     ClientCommand("alias \"noclip\" \"script GetPlayerArray()[0].SetPhysics( GetPlayerArray()[0].IsNoclipping() ? MOVETYPE_WALK : MOVETYPE_NOCLIP )\"") // script only works with sv_cheats 1 on.
+    ClientCommand("ailas \"resethelmets\" \"script_ui ResetCollectiblesProgress_All()\"")
+
+    // finally, an autoexec!
+    ClientCommand("exec autoexec")
 }
 
 void function ResetAnyPercent()
@@ -19,7 +23,7 @@ void function ResetAnyPercent()
 
     SetConVarBool( "sv_cheats", false )
     SetConVarFloat("player_respawnInputDebounceDuration", 0.5)
-    
+
     ClientCommand("set_loading_progress_detente #INTROSCREEN_HINT_PC #INTROSCREEN_HINT_CONSOLE")
 
     ClientCommand( "fgr" )
@@ -30,10 +34,10 @@ void function ResetAllHelmets()
     SetConVarString( "igt_run_category", "all helmets" )
 
     ResetCollectiblesProgress_All()
-    
+
     SetConVarBool( "sv_cheats", false )
     SetConVarFloat("player_respawnInputDebounceDuration", 0.5)
-    
+
     ClientCommand("set_loading_progress_detente #INTROSCREEN_HINT_PC #INTROSCREEN_HINT_CONSOLE")
 
     ClientCommand( "fgr" )


### PR DESCRIPTION
- makes the timer always add 18hrbypass time when it loads the bypass
- makes you touch the ground on savestate to hopefully fix double jumps
- adds `resethelmets` alias to run reset helmets script
- loads autoexec.cfg automatically
- adds SDK/ronin version to loading screen to aid verification